### PR TITLE
[2.3.x]Typo 'subtotal' paypal catalog controller

### DIFF
--- a/catalog/controller/extension/payment/paypal.php
+++ b/catalog/controller/extension/payment/paypal.php
@@ -2633,7 +2633,7 @@ class ControllerExtensionPaymentPayPal extends Controller {
 
 				if ($affiliate_info) {
 					$order_data['affiliate_id'] = $affiliate_info['affiliate_id'];
-					$order_data['commission'] = ($subtotal / 100) * $affiliate_info['commission'];
+					$order_data['commission'] = ($sub_total / 100) * $affiliate_info['commission'];
 				} else {
 					$order_data['affiliate_id'] = 0;
 					$order_data['commission'] = 0;


### PR DESCRIPTION
You use:

`$sub_total = $this->cart->getSubTotal();`

but here is not used

`$order_data['commission'] = ($subtotal / 100) * $affiliate_info['commission'];`

Same issue in 2.2.x branch

